### PR TITLE
Update pytm.py - remove html encoding markdown data, as pandoc do the…

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1090,8 +1090,8 @@ a brief description of the system being modeled."""
                 e, f"while trying to open the report template file ({template_path})."
             )
 
-        threats = encode_threat_data(TM._threats)
-        findings = encode_threat_data(self.findings)
+        threats = TM._threats
+        findings = self.findings
 
         elements = encode_element_threat_data(TM._elements)
         assets = encode_element_threat_data(TM._assets)


### PR DESCRIPTION
removed HTML encoding the "threats" as 
it makes the payload data in the 'examples' section of the final HTML report show incorrectly. 
Pandoc encodes HTML during HTML generation, while still allowing users to see the correct representation visually. 
Threats and findings come from bundled threat.json, not something entered by the user or written by the end-user.

related to https://github.com/OWASP/pytm/issues/256